### PR TITLE
Add demo website skeleton for voice platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # GPT5_playarea1
+
+## Demo Website
+
+This repository includes a simple demo website with placeholder pages for a voice platform.
+
+To view it locally, run:
+
+```bash
+python -m http.server 8000
+```
+
+Then visit [http://localhost:8000/index.html](http://localhost:8000/index.html).

--- a/analytics.html
+++ b/analytics.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Analytics - Voice Platform Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="navbar"></div>
+  <main>
+    <h1>Analytics</h1>
+    <p>Dashboards and metrics for call activity.</p>
+    <ul>
+      <li>Overview, inbound, outbound, unanswered, user activity.</li>
+      <li>Common metrics: calls, answer rate, ASA, AHT, CSAT.</li>
+      <li>Graphs: time series, distributions, funnels, leaderboards.</li>
+    </ul>
+  </main>
+  <script>
+    fetch('nav.html').then(r => r.text()).then(html => document.getElementById('navbar').innerHTML = html);
+  </script>
+</body>
+</html>

--- a/audit-log.html
+++ b/audit-log.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Audit Log - Voice Platform Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="navbar"></div>
+  <main>
+    <h1>Audit Log</h1>
+    <p>Track changes and sensitive actions.</p>
+    <ul>
+      <li>Record who, what, when for each change.</li>
+      <li>Log sensitive views like PII reveals and downloads.</li>
+      <li>Exportable entries.</li>
+    </ul>
+  </main>
+  <script>
+    fetch('nav.html').then(r => r.text()).then(html => document.getElementById('navbar').innerHTML = html);
+  </script>
+</body>
+</html>

--- a/billing.html
+++ b/billing.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Billing - Voice Platform Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="navbar"></div>
+  <main>
+    <h1>Billing</h1>
+    <p>Plans, invoices, and usage.</p>
+    <ul>
+      <li>View plan limits and add-ons.</li>
+      <li>Manage invoices, payment method, VAT.</li>
+      <li>Usage graphs for minutes and storage.</li>
+    </ul>
+  </main>
+  <script>
+    fetch('nav.html').then(r => r.text()).then(html => document.getElementById('navbar').innerHTML = html);
+  </script>
+</body>
+</html>

--- a/calls.html
+++ b/calls.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Calls - Voice Platform Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="navbar"></div>
+  <main>
+    <h1>Calls</h1>
+    <p>Filter and inspect individual calls.</p>
+    <ul>
+      <li>Filters: date range, number, IVR branch, tag, outcome, agent, status.</li>
+      <li>Columns: timestamp, caller, number dialled, IVR branch, outcome, duration, tags, transcript status, recording, booking link, notes.</li>
+      <li>Row drawer: transcript, recording player, outcome, AI summary, PII reveal.</li>
+    </ul>
+  </main>
+  <script>
+    fetch('nav.html').then(r => r.text()).then(html => document.getElementById('navbar').innerHTML = html);
+  </script>
+</body>
+</html>

--- a/compliance-privacy.html
+++ b/compliance-privacy.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Compliance & Privacy - Voice Platform Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="navbar"></div>
+  <main>
+    <h1>Compliance &amp; Privacy</h1>
+    <p>Control recording consent and data retention.</p>
+    <ul>
+      <li>Recording consent settings and regional rules.</li>
+      <li>Data retention policies and PII handling.</li>
+      <li>GDPR and HIPAA tools.</li>
+    </ul>
+  </main>
+  <script>
+    fetch('nav.html').then(r => r.text()).then(html => document.getElementById('navbar').innerHTML = html);
+  </script>
+</body>
+</html>

--- a/contacts.html
+++ b/contacts.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Contacts - Voice Platform Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="navbar"></div>
+  <main>
+    <h1>Contacts</h1>
+    <p>Manage callers and their history.</p>
+    <ul>
+      <li>Views: All, New, VIP, Blocked, Recently active.</li>
+      <li>Record page: identity, timeline, intents, notes, block options.</li>
+    </ul>
+  </main>
+  <script>
+    fetch('nav.html').then(r => r.text()).then(html => document.getElementById('navbar').innerHTML = html);
+  </script>
+</body>
+</html>

--- a/developers.html
+++ b/developers.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Developers - Voice Platform Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="navbar"></div>
+  <main>
+    <h1>Developers</h1>
+    <p>API keys and webhooks.</p>
+    <ul>
+      <li>Generate API keys with scopes.</li>
+      <li>Manage webhook subscriptions and logs.</li>
+      <li>Example snippets for testing.</li>
+    </ul>
+  </main>
+  <script>
+    fetch('nav.html').then(r => r.text()).then(html => document.getElementById('navbar').innerHTML = html);
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Home - Voice Platform Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="navbar"></div>
+  <main>
+    <h1>Overview</h1>
+    <p>Snapshot of health and quick actions.</p>
+    <div class="card-container">
+      <div class="card"><h3>Calls Today</h3><p>0</p></div>
+      <div class="card"><h3>Calls This Week</h3><p>0</p></div>
+      <div class="card"><h3>Calls Last 30 Days</h3><p>0</p></div>
+      <div class="card"><h3>Answer Rate</h3><p>0%</p></div>
+      <div class="card"><h3>Avg Speed to Answer</h3><p>0s</p></div>
+      <div class="card"><h3>Avg Handle Time</h3><p>0s</p></div>
+      <div class="card"><h3>Missed Calls</h3><p>0</p></div>
+      <div class="card"><h3>Bookings Created</h3><p>0</p></div>
+    </div>
+    <p>Charts for call volume, answer rate heatmap, top intents, and bookings funnel would appear here.</p>
+  </main>
+  <script>
+    fetch('nav.html').then(r => r.text()).then(html => document.getElementById('navbar').innerHTML = html);
+  </script>
+</body>
+</html>

--- a/integrations.html
+++ b/integrations.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Integrations - Voice Platform Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="navbar"></div>
+  <main>
+    <h1>Integrations</h1>
+    <p>Connect external systems.</p>
+    <ul>
+      <li>Calendars & meetings via Cal.com.</li>
+      <li>CRM and help desk integrations.</li>
+      <li>Comms providers and automation tools.</li>
+    </ul>
+  </main>
+  <script>
+    fetch('nav.html').then(r => r.text()).then(html => document.getElementById('navbar').innerHTML = html);
+  </script>
+</body>
+</html>

--- a/live.html
+++ b/live.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Live - Voice Platform Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="navbar"></div>
+  <main>
+    <h1>Live</h1>
+    <p>Real-time monitoring and controls.</p>
+    <ul>
+      <li>Widgets: calls in queue, live ASA, agent status, numbers view, events stream.</li>
+      <li>Controls: monitor, whisper, barge, overflow toggle, close lines.</li>
+    </ul>
+  </main>
+  <script>
+    fetch('nav.html').then(r => r.text()).then(html => document.getElementById('navbar').innerHTML = html);
+  </script>
+</body>
+</html>

--- a/nav.html
+++ b/nav.html
@@ -1,0 +1,19 @@
+<nav>
+  <ul class="nav-list">
+    <li><a href="index.html">Home</a></li>
+    <li><a href="calls.html">Calls</a></li>
+    <li><a href="live.html">Live</a></li>
+    <li><a href="contacts.html">Contacts</a></li>
+    <li><a href="scripts-ai.html">Scripts &amp; AI</a></li>
+    <li><a href="numbers-routing.html">Numbers &amp; Routing</a></li>
+    <li><a href="schedules.html">Schedules</a></li>
+    <li><a href="voicemail-recordings.html">Voicemail &amp; Recordings</a></li>
+    <li><a href="analytics.html">Analytics</a></li>
+    <li><a href="integrations.html">Integrations</a></li>
+    <li><a href="team-roles.html">Team &amp; Roles</a></li>
+    <li><a href="billing.html">Billing</a></li>
+    <li><a href="compliance-privacy.html">Compliance &amp; Privacy</a></li>
+    <li><a href="developers.html">Developers</a></li>
+    <li><a href="audit-log.html">Audit Log</a></li>
+  </ul>
+</nav>

--- a/numbers-routing.html
+++ b/numbers-routing.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Numbers & Routing - Voice Platform Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="navbar"></div>
+  <main>
+    <h1>Numbers &amp; Routing</h1>
+    <p>Manage phone numbers and call flows.</p>
+    <ul>
+      <li>Inventory of numbers with status and recording options.</li>
+      <li>Connect/port numbers or bring your PBX via SIP.</li>
+      <li>Routing rules: schedules, IVR, geo-routing, overflow, recording policy.</li>
+    </ul>
+  </main>
+  <script>
+    fetch('nav.html').then(r => r.text()).then(html => document.getElementById('navbar').innerHTML = html);
+  </script>
+</body>
+</html>

--- a/schedules.html
+++ b/schedules.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Schedules - Voice Platform Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="navbar"></div>
+  <main>
+    <h1>Schedules</h1>
+    <p>Define business hours and availability.</p>
+    <ul>
+      <li>Business hours per location.</li>
+      <li>Holidays and exceptions.</li>
+      <li>On-call rotations and meeting availability.</li>
+    </ul>
+  </main>
+  <script>
+    fetch('nav.html').then(r => r.text()).then(html => document.getElementById('navbar').innerHTML = html);
+  </script>
+</body>
+</html>

--- a/scripts-ai.html
+++ b/scripts-ai.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Scripts & AI - Voice Platform Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="navbar"></div>
+  <main>
+    <h1>Scripts &amp; AI</h1>
+    <p>Define playbooks, prompts, and knowledge.</p>
+    <ul>
+      <li>Playbooks: lead intake, support triage, payments, etc.</li>
+      <li>Prompts & brand voice, knowledge base, intents & routing.</li>
+      <li>Fallbacks, compliance guardrails, testing zone.</li>
+    </ul>
+  </main>
+  <script>
+    fetch('nav.html').then(r => r.text()).then(html => document.getElementById('navbar').innerHTML = html);
+  </script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,44 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  background-color: #333;
+}
+
+.nav-list li {
+  margin: 0;
+}
+
+.nav-list li a {
+  display: block;
+  padding: 14px 20px;
+  color: white;
+  text-decoration: none;
+}
+
+.nav-list li a:hover {
+  background-color: #575757;
+}
+
+main {
+  padding: 20px;
+}
+
+.card-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.card {
+  border: 1px solid #ccc;
+  padding: 10px;
+  width: 200px;
+}

--- a/team-roles.html
+++ b/team-roles.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Team & Roles - Voice Platform Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="navbar"></div>
+  <main>
+    <h1>Team &amp; Roles</h1>
+    <p>Manage users and permissions.</p>
+    <ul>
+      <li>Invite users, SSO, MFA.</li>
+      <li>Role-based access for recordings, PII, exports.</li>
+      <li>Per-user settings and status controls.</li>
+    </ul>
+  </main>
+  <script>
+    fetch('nav.html').then(r => r.text()).then(html => document.getElementById('navbar').innerHTML = html);
+  </script>
+</body>
+</html>

--- a/voicemail-recordings.html
+++ b/voicemail-recordings.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Voicemail & Recordings - Voice Platform Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="navbar"></div>
+  <main>
+    <h1>Voicemail &amp; Recordings</h1>
+    <p>Manage voicemails and audio files.</p>
+    <ul>
+      <li>Voicemail inbox with transcripts and summaries.</li>
+      <li>Greeting library and retention policies.</li>
+      <li>Bulk actions for management.</li>
+    </ul>
+  </main>
+  <script>
+    fetch('nav.html').then(r => r.text()).then(html => document.getElementById('navbar').innerHTML = html);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add navigation and placeholder pages for voice platform sections
- include basic home dashboard with KPI card placeholders
- document how to serve the static demo locally

## Testing
- `python -m http.server 8000 & sleep 2; kill $!`


------
https://chatgpt.com/codex/tasks/task_e_6895ec66da988323990aa5169dacaf69