### PR TITLE
Add glassmorphic single-page demo portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # GPT5_playarea1
+
+## Demo Portal
+
+This repository contains a single-page demo portal for a futuristic voice platform. It showcases top-level sections like Calls, Live monitoring, Contacts and more with an Apple-style glassmorphism design.
+
+### Run Locally
+
+Serve the files and open the portal in your browser:
+
+```bash
+python -m http.server 8000
+```
+
+Then visit [http://localhost:8000/index.html](http://localhost:8000/index.html).

--- a/index.html
+++ b/index.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Voice Platform Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <nav class="glass">
+    <a href="#" data-section="home" class="active">Home</a>
+    <a href="#" data-section="calls">Calls</a>
+    <a href="#" data-section="live">Live</a>
+    <a href="#" data-section="contacts">Contacts</a>
+    <a href="#" data-section="scripts">Scripts &amp; AI</a>
+    <a href="#" data-section="numbers">Numbers &amp; Routing</a>
+    <a href="#" data-section="schedules">Schedules</a>
+    <a href="#" data-section="voicemail">Voicemail</a>
+    <a href="#" data-section="analytics">Analytics</a>
+    <a href="#" data-section="integrations">Integrations</a>
+    <a href="#" data-section="team">Team &amp; Roles</a>
+    <a href="#" data-section="billing">Billing</a>
+    <a href="#" data-section="compliance">Compliance</a>
+    <a href="#" data-section="developers">Developers</a>
+    <a href="#" data-section="audit">Audit Log</a>
+  </nav>
+  <main>
+    <section id="home" class="section glass active">
+      <h1>Overview</h1>
+      <div class="card-container">
+        <div class="card glass"><h3>Calls Today</h3><p>0</p></div>
+        <div class="card glass"><h3>Answer Rate</h3><p>0%</p></div>
+        <div class="card glass"><h3>Avg Speed to Answer</h3><p>0s</p></div>
+        <div class="card glass"><h3>Avg Handle Time</h3><p>0s</p></div>
+        <div class="card glass"><h3>Missed Calls</h3><p>0</p></div>
+        <div class="card glass"><h3>Bookings</h3><p>0</p></div>
+      </div>
+      <p>Charts for volume, answer rate heatmap, top intents and funnel would appear here.</p>
+    </section>
+
+    <section id="calls" class="section glass">
+      <h1>Calls</h1>
+      <p>Filter and review past calls with transcripts, recordings and tags.</p>
+    </section>
+
+    <section id="live" class="section glass">
+      <h1>Live</h1>
+      <p>Real-time wallboard showing queues, agent status and live controls.</p>
+    </section>
+
+    <section id="contacts" class="section glass">
+      <h1>Contacts</h1>
+      <p>Manage callers with interaction history, notes and tags.</p>
+    </section>
+
+    <section id="scripts" class="section glass">
+      <h1>Scripts &amp; AI</h1>
+      <p>Configure playbooks, prompts, knowledge and testing zone.</p>
+    </section>
+
+    <section id="numbers" class="section glass">
+      <h1>Numbers &amp; Routing</h1>
+      <p>Manage phone numbers, SIP trunks and routing rules.</p>
+    </section>
+
+    <section id="schedules" class="section glass">
+      <h1>Schedules</h1>
+      <p>Define business hours, holidays and on-call rotations.</p>
+    </section>
+
+    <section id="voicemail" class="section glass">
+      <h1>Voicemail &amp; Recordings</h1>
+      <p>Review voicemail inbox, transcripts and retention policies.</p>
+    </section>
+
+    <section id="analytics" class="section glass">
+      <h1>Analytics</h1>
+      <p>Dashboards for inbound performance, user activity and AI quality.</p>
+    </section>
+
+    <section id="integrations" class="section glass">
+      <h1>Integrations</h1>
+      <p>Connect calendars, CRMs, webhooks and communication providers.</p>
+    </section>
+
+    <section id="team" class="section glass">
+      <h1>Team &amp; Roles</h1>
+      <p>Invite users, manage roles and permissions.</p>
+    </section>
+
+    <section id="billing" class="section glass">
+      <h1>Billing</h1>
+      <p>Plan, usage and invoices.</p>
+    </section>
+
+    <section id="compliance" class="section glass">
+      <h1>Compliance &amp; Privacy</h1>
+      <p>Recording consent, data retention and PII handling settings.</p>
+    </section>
+
+    <section id="developers" class="section glass">
+      <h1>Developers</h1>
+      <p>API keys, webhooks and example snippets.</p>
+    </section>
+
+    <section id="audit" class="section glass">
+      <h1>Audit Log</h1>
+      <p>Track every change with who, what and when.</p>
+    </section>
+  </main>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,14 @@
+// Simple navigation handler for single-page demo
+const navLinks = document.querySelectorAll('nav a');
+const sections = document.querySelectorAll('main section');
+
+navLinks.forEach(link => {
+  link.addEventListener('click', e => {
+    e.preventDefault();
+    const target = link.getAttribute('data-section');
+    sections.forEach(sec => sec.classList.remove('active'));
+    navLinks.forEach(l => l.classList.remove('active'));
+    document.getElementById(target).classList.add('active');
+    link.classList.add('active');
+  });
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,65 @@
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  margin: 0;
+  color: #fff;
+  min-height: 100vh;
+  background: linear-gradient(135deg, #1f1c2c, #928DAB);
+}
+
+nav {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+  padding: 1rem;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+nav a {
+  color: #fff;
+  text-decoration: none;
+  padding: 0.5rem 1rem;
+  border-radius: 12px;
+  transition: background 0.3s;
+}
+
+nav a.active,
+nav a:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+main {
+  padding: 2rem;
+}
+
+.section {
+  display: none;
+  margin: 0 auto;
+  max-width: 900px;
+  padding: 2rem;
+}
+
+.section.active {
+  display: block;
+}
+
+.card-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.card {
+  flex: 1 1 200px;
+  padding: 1rem;
+}
+
+.glass {
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
+  backdrop-filter: blur(10px);
+}


### PR DESCRIPTION
## Summary
- consolidate all sections into one navigation-driven page
- add Apple-style glassmorphism with gradient background and translucent cards
- include lightweight script for dynamic section switching

## Testing
- `python -m http.server 8000 & sleep 2; curl -I http://localhost:8000/index.html; kill $!`


------
https://chatgpt.com/codex/tasks/task_e_6895ec66da988323990aa5169dacaf69